### PR TITLE
Fix #1: Support active hours for gh-issue-autopilot

### DIFF
--- a/skills/gh-issue-autopilot/SKILL.md
+++ b/skills/gh-issue-autopilot/SKILL.md
@@ -4,7 +4,7 @@ description: Solve GitHub Issues automatically or interactively. No args = autop
 model: haiku
 disable-model-invocation: true
 allowed-tools: Bash, Read, Edit, Write, Glob, Grep, Agent, Skill, CronCreate, CronDelete
-argument-hint: "[<issue-number> | stop | setup | label <name> | interval <minutes> | model <name>]"
+argument-hint: "[<issue-number> | stop | setup | label <name> | interval <minutes> | model <name> | hours <start>-<end>]"
 ---
 
 # GitHub Issue Autopilot
@@ -20,6 +20,7 @@ Solve GitHub Issues either automatically (loop mode in a worktree) or interactiv
 - `/gh-issue-autopilot label <name>` — Set the GitHub issue label used by automatic mode (default: `Claude`).
 - `/gh-issue-autopilot interval <minutes>` — Set the scan interval in minutes (default: `5`).
 - `/gh-issue-autopilot model <name>` — Set the model used for implementation subagents (default: `opus`). Accepts: `opus`, `sonnet`, or `haiku`.
+- `/gh-issue-autopilot hours <start>-<end>` — Set active hours for scanning (e.g., `9-17` for 9 AM to 5 PM). Use `hours off` to disable (scan anytime). Supports overnight ranges (e.g., `22-6`).
 
 ## Argument Routing
 
@@ -31,6 +32,7 @@ Parse the argument to determine the mode:
 - `label ...` → **Label config** (everything after `label ` is the label name)
 - `interval ...` → **Interval config** (everything after `interval ` is the number of minutes)
 - `model ...` → **Model config** (everything after `model ` is the model name)
+- `hours ...` → **Hours config** (everything after `hours ` is the range, e.g., `9-17` or `off`)
 - A number (e.g., `123`) → **Manual mode** for that issue number
 - Anything else → treat as automatic mode
 
@@ -48,9 +50,12 @@ Stored in the repo's `.claude/` directory. Persists across sessions.
 {
   "label": "Claude",
   "interval": 5,
-  "model": "opus"
+  "model": "opus",
+  "activeHours": { "start": 9, "end": 17 }
 }
 ```
+
+The `activeHours` field is optional. When omitted, scanning is always active.
 
 ### Runtime state (ephemeral, per-repo)
 
@@ -109,6 +114,25 @@ Controls which model is used for implementation subagents. The skill itself alwa
 4. Write the updated config back to `.claude/autopilot-config.json`.
 5. Tell the user the implementation model has been updated.
 
+### Active hours configuration (`/gh-issue-autopilot hours <start>-<end>`)
+
+Controls when scanning is active. Outside active hours, the pre-check script exits immediately without making any API calls or spending tokens. Uses the system's local time.
+
+1. Read the current config from `.claude/autopilot-config.json` (or start with defaults).
+2. If the argument is `off`, remove the `activeHours` field from the config (scanning becomes always active).
+3. Otherwise, parse the argument as `<start>-<end>` where both are integers 0-23.
+4. Validate that both start and end are integers in the range 0-23.
+5. Set the `activeHours` field to `{"start": <start>, "end": <end>}`.
+6. Write the updated config back to `.claude/autopilot-config.json`.
+7. Tell the user the active hours have been updated.
+8. Note: the change takes effect on the next scan cycle. No restart required.
+
+**Range behavior:**
+- Normal range (start < end): active from start up to (but not including) end. E.g., `9-17` means 9:00 AM through 4:59 PM.
+- Overnight range (start > end): active from start through midnight and from midnight up to end. E.g., `22-6` means 10:00 PM through 5:59 AM.
+- Same values (start == end): scanning is effectively disabled (zero-width window).
+- No `activeHours` in config: scanning is always active (default behavior).
+
 ---
 
 ## Setup (`/gh-issue-autopilot setup`)
@@ -129,6 +153,7 @@ Run these checks and report pass/fail for each:
 8. **Label exists in repo**: `gh label list --json name --jq '.[].name'` — check if the configured label exists (case-insensitive). If not, offer to create it.
 9. **Scan interval**: Read from `.claude/autopilot-config.json` or show default (`5` minutes)
 10. **Implementation model**: Read from `.claude/autopilot-config.json` or show default (`opus`). This is the model used for subagents that solve issues and address reviews. Explain that the skill runs on Haiku for triage and only escalates to this model for implementation. Ask the user if they'd like to change it (options: `opus`, `sonnet`, `haiku`).
+11. **Active hours**: Read from `.claude/autopilot-config.json`. If `activeHours` is set, show the configured range (e.g., `9-17`). If not set, show "always active (no restriction)". Ask the user if they'd like to configure active hours.
 
 ### Step 2: Check CLAUDE.md
 
@@ -185,7 +210,7 @@ Run the pre-check script as the very first action. This avoids burning tokens on
 ```bash
 bash "$(dirname "$(readlink -f ~/.claude/skills/gh-issue-autopilot/SKILL.md)")/precheck.sh"
 ```
-- If it exits **non-zero**: say "No work found." and **stop immediately**. Do not run any other commands.
+- If it exits **non-zero**: say "No work found." and **stop immediately**. Do not run any other commands. This also covers active hours — if the current time is outside configured active hours, the pre-check exits non-zero with `OUTSIDE_ACTIVE_HOURS`.
 - If it exits **zero**: proceed with the triage below.
 
 **Step 1 — Triage (runs on Haiku via the `model: haiku` frontmatter):**

--- a/skills/gh-issue-autopilot/precheck.sh
+++ b/skills/gh-issue-autopilot/precheck.sh
@@ -4,10 +4,44 @@
 # Exit 0 = work to do (proceed with scan), exit 1 = no work (skip scan).
 #
 # Checks:
+# 0. If outside configured active hours → no work (skip before any API calls)
 # 1. If an active issue exists → work to do (need to check PR status)
 # 2. If open issues with the configured label exist → work to do
 # 3. Otherwise → no work
 set -euo pipefail
+
+# ── Active hours check (before any API calls) ──────────────────────
+# Uses CURRENT_HOUR env var if set (for testing), otherwise system local time.
+CONFIG_FILE=".claude/autopilot-config.json"
+if [ -f "$CONFIG_FILE" ]; then
+  AH_START=$(grep -o '"start"[[:space:]]*:[[:space:]]*[0-9]\+' "$CONFIG_FILE" 2>/dev/null \
+    | head -1 | sed 's/.*:[[:space:]]*//' || true)
+  AH_END=$(grep -o '"end"[[:space:]]*:[[:space:]]*[0-9]\+' "$CONFIG_FILE" 2>/dev/null \
+    | head -1 | sed 's/.*:[[:space:]]*//' || true)
+
+  # Only enforce if both start and end are present (activeHours is configured)
+  if [ -n "$AH_START" ] && [ -n "$AH_END" ]; then
+    HOUR="${CURRENT_HOUR:-$(date +%-H)}"
+
+    if [ "$AH_START" -eq "$AH_END" ]; then
+      # Zero-width window: always outside
+      echo "OUTSIDE_ACTIVE_HOURS"
+      exit 1
+    elif [ "$AH_START" -lt "$AH_END" ]; then
+      # Normal range (e.g., 9-17)
+      if [ "$HOUR" -lt "$AH_START" ] || [ "$HOUR" -ge "$AH_END" ]; then
+        echo "OUTSIDE_ACTIVE_HOURS"
+        exit 1
+      fi
+    else
+      # Overnight range (e.g., 22-6): active when hour >= start OR hour < end
+      if [ "$HOUR" -lt "$AH_START" ] && [ "$HOUR" -ge "$AH_END" ]; then
+        echo "OUTSIDE_ACTIVE_HOURS"
+        exit 1
+      fi
+    fi
+  fi
+fi
 
 # Compute runtime dir
 REPO_ID=$(gh repo view --json url --jq '.url' | md5sum | cut -c1-12)
@@ -23,8 +57,7 @@ if [ -f "$RUNTIME_DIR/active-issue-manual.txt" ]; then
   exit 0
 fi
 
-# Read label from config
-CONFIG_FILE=".claude/autopilot-config.json"
+# Read label from config (CONFIG_FILE already set above)
 LABEL="Claude"
 if [ -f "$CONFIG_FILE" ]; then
   PARSED=$(grep -o '"label"[[:space:]]*:[[:space:]]*"[^"]*"' "$CONFIG_FILE" 2>/dev/null \

--- a/tests/gh-issue-autopilot/test-active-hours.sh
+++ b/tests/gh-issue-autopilot/test-active-hours.sh
@@ -1,0 +1,277 @@
+#!/usr/bin/env bash
+# Tests for active hours configuration and precheck enforcement
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../helpers.sh"
+
+PRECHECK="$REPO_ROOT/skills/gh-issue-autopilot/precheck.sh"
+
+echo -e "${BOLD}gh-issue-autopilot: Active Hours${RESET}"
+echo ""
+
+# Use a temp directory to simulate a repo's .claude/ dir
+TEMP_DIR="$(mktemp -d)"
+CONFIG_DIR="$TEMP_DIR/.claude"
+CONFIG_FILE="$CONFIG_DIR/autopilot-config.json"
+trap 'cleanup_temp "$TEMP_DIR"' EXIT
+
+# ══════════════════════════════════════════════════════════════════
+# Config parsing tests
+# ══════════════════════════════════════════════════════════════════
+
+echo -e "${BOLD}── Config Parsing ──${RESET}"
+echo ""
+
+# Helper: extract activeHours start/end using the same grep logic as precheck.sh
+get_active_hours_start() {
+  local cfg="$1"
+  if [ -f "$cfg" ]; then
+    local match
+    match="$(grep -o '"start"[[:space:]]*:[[:space:]]*[0-9]\+' "$cfg" 2>/dev/null \
+      | head -1 | sed 's/.*:[[:space:]]*//' || true)"
+    echo "${match:-}"
+  fi
+}
+
+get_active_hours_end() {
+  local cfg="$1"
+  if [ -f "$cfg" ]; then
+    local match
+    match="$(grep -o '"end"[[:space:]]*:[[:space:]]*[0-9]\+' "$cfg" 2>/dev/null \
+      | head -1 | sed 's/.*:[[:space:]]*//' || true)"
+    echo "${match:-}"
+  fi
+}
+
+# ── No config file ──────────────────────────────────────────────
+
+echo -e "${BOLD}No config file${RESET}"
+
+test_start "no config"
+start="$(get_active_hours_start "$CONFIG_FILE")"
+end_val="$(get_active_hours_end "$CONFIG_FILE")"
+assert_equals "start is empty" "" "$start"
+assert_equals "end is empty" "" "$end_val"
+
+# ── Config without activeHours ──────────────────────────────────
+
+echo ""
+echo -e "${BOLD}Config without activeHours${RESET}"
+
+mkdir -p "$CONFIG_DIR"
+echo '{"label": "Claude", "interval": 5}' > "$CONFIG_FILE"
+
+test_start "no activeHours field"
+start="$(get_active_hours_start "$CONFIG_FILE")"
+end_val="$(get_active_hours_end "$CONFIG_FILE")"
+assert_equals "start is empty" "" "$start"
+assert_equals "end is empty" "" "$end_val"
+
+# ── Config with activeHours ─────────────────────────────────────
+
+echo ""
+echo -e "${BOLD}Config with activeHours${RESET}"
+
+echo '{"label": "Claude", "activeHours": {"start": 9, "end": 17}}' > "$CONFIG_FILE"
+
+test_start "standard active hours"
+start="$(get_active_hours_start "$CONFIG_FILE")"
+end_val="$(get_active_hours_end "$CONFIG_FILE")"
+assert_equals "start is 9" "9" "$start"
+assert_equals "end is 17" "17" "$end_val"
+
+# ── Overnight range ─────────────────────────────────────────────
+
+echo ""
+echo -e "${BOLD}Overnight range${RESET}"
+
+echo '{"activeHours": {"start": 22, "end": 6}}' > "$CONFIG_FILE"
+
+test_start "overnight active hours"
+start="$(get_active_hours_start "$CONFIG_FILE")"
+end_val="$(get_active_hours_end "$CONFIG_FILE")"
+assert_equals "start is 22" "22" "$start"
+assert_equals "end is 6" "6" "$end_val"
+
+# ── Zero hour values ────────────────────────────────────────────
+
+echo ""
+echo -e "${BOLD}Zero hour values${RESET}"
+
+echo '{"activeHours": {"start": 0, "end": 0}}' > "$CONFIG_FILE"
+
+test_start "start and end both zero"
+start="$(get_active_hours_start "$CONFIG_FILE")"
+end_val="$(get_active_hours_end "$CONFIG_FILE")"
+assert_equals "start is 0" "0" "$start"
+assert_equals "end is 0" "0" "$end_val"
+
+# ══════════════════════════════════════════════════════════════════
+# Precheck integration tests (using CURRENT_HOUR override)
+# ══════════════════════════════════════════════════════════════════
+
+# These tests require gh auth to run (precheck.sh calls gh)
+if gh auth status >/dev/null 2>&1; then
+
+  echo ""
+  echo -e "${BOLD}── Precheck Active Hours Enforcement (live) ──${RESET}"
+  echo ""
+
+  # Save and restore real config
+  REAL_CONFIG="$REPO_ROOT/.claude/autopilot-config.json"
+  BACKUP_FILE="$TEMP_DIR/autopilot-config.json.bak"
+  if [ -f "$REAL_CONFIG" ]; then
+    cp "$REAL_CONFIG" "$BACKUP_FILE"
+  fi
+  mkdir -p "$REPO_ROOT/.claude"
+
+  # Compute runtime dir and temporarily hide active issue files
+  REPO_ID=$(gh repo view --json url --jq '.url' | md5sum | cut -c1-12)
+  RUNTIME_DIR="/tmp/autopilot-${REPO_ID}"
+  mkdir -p "$RUNTIME_DIR"
+  for f in "$RUNTIME_DIR"/active-issue-*.txt; do
+    [ -f "$f" ] && mv "$f" "${f}.hours-bak"
+  done
+
+  restore_state() {
+    # Restore active issue files
+    for f in "$RUNTIME_DIR"/active-issue-*.txt.hours-bak; do
+      [ -f "$f" ] && mv "$f" "${f%.hours-bak}"
+    done
+    # Restore config
+    if [ -f "$BACKUP_FILE" ]; then
+      mv "$BACKUP_FILE" "$REAL_CONFIG"
+    else
+      rm -f "$REAL_CONFIG"
+    fi
+  }
+  trap 'restore_state; cleanup_temp "$TEMP_DIR"' EXIT
+
+  # Use a label that won't match any real issues
+  BASE_CONFIG='{"label": "nonexistent-label-xyz-99999"'
+
+  # ── No activeHours: precheck should NOT block on hours ────────
+
+  echo -e "${BOLD}No activeHours configured${RESET}"
+
+  echo "${BASE_CONFIG}}" > "$REAL_CONFIG"
+
+  test_start "no activeHours does not block"
+  output="$(cd "$REPO_ROOT" && CURRENT_HOUR=3 bash "$PRECHECK" 2>&1)" && exit_code=0 || exit_code=$?
+  # Should exit non-zero because no matching issues, but NOT because of hours
+  assert_equals "exits non-zero (no work)" "1" "$exit_code"
+  assert_contains "output is NO_WORK (not hours)" "$output" "NO_WORK"
+
+  # ── Normal range: inside active hours ─────────────────────────
+
+  echo ""
+  echo -e "${BOLD}Normal range (9-17): inside${RESET}"
+
+  echo "${BASE_CONFIG}, \"activeHours\": {\"start\": 9, \"end\": 17}}" > "$REAL_CONFIG"
+
+  test_start "hour 12 inside 9-17"
+  output="$(cd "$REPO_ROOT" && CURRENT_HOUR=12 bash "$PRECHECK" 2>&1)" && exit_code=0 || exit_code=$?
+  assert_equals "exits non-zero (no work, but not hours)" "1" "$exit_code"
+  assert_contains "output is NO_WORK" "$output" "NO_WORK"
+
+  test_start "hour 9 inside 9-17 (boundary)"
+  output="$(cd "$REPO_ROOT" && CURRENT_HOUR=9 bash "$PRECHECK" 2>&1)" && exit_code=0 || exit_code=$?
+  assert_contains "output is NO_WORK" "$output" "NO_WORK"
+
+  # ── Normal range: outside active hours ────────────────────────
+
+  echo ""
+  echo -e "${BOLD}Normal range (9-17): outside${RESET}"
+
+  test_start "hour 5 outside 9-17"
+  output="$(cd "$REPO_ROOT" && CURRENT_HOUR=5 bash "$PRECHECK" 2>&1)" && exit_code=0 || exit_code=$?
+  assert_equals "exits non-zero" "1" "$exit_code"
+  assert_contains "output is OUTSIDE_ACTIVE_HOURS" "$output" "OUTSIDE_ACTIVE_HOURS"
+
+  test_start "hour 17 outside 9-17 (boundary, end is exclusive)"
+  output="$(cd "$REPO_ROOT" && CURRENT_HOUR=17 bash "$PRECHECK" 2>&1)" && exit_code=0 || exit_code=$?
+  assert_contains "output is OUTSIDE_ACTIVE_HOURS" "$output" "OUTSIDE_ACTIVE_HOURS"
+
+  test_start "hour 23 outside 9-17"
+  output="$(cd "$REPO_ROOT" && CURRENT_HOUR=23 bash "$PRECHECK" 2>&1)" && exit_code=0 || exit_code=$?
+  assert_contains "output is OUTSIDE_ACTIVE_HOURS" "$output" "OUTSIDE_ACTIVE_HOURS"
+
+  # ── Overnight range: inside active hours ──────────────────────
+
+  echo ""
+  echo -e "${BOLD}Overnight range (22-6): inside${RESET}"
+
+  echo "${BASE_CONFIG}, \"activeHours\": {\"start\": 22, \"end\": 6}}" > "$REAL_CONFIG"
+
+  test_start "hour 23 inside 22-6"
+  output="$(cd "$REPO_ROOT" && CURRENT_HOUR=23 bash "$PRECHECK" 2>&1)" && exit_code=0 || exit_code=$?
+  assert_contains "output is NO_WORK" "$output" "NO_WORK"
+
+  test_start "hour 0 inside 22-6"
+  output="$(cd "$REPO_ROOT" && CURRENT_HOUR=0 bash "$PRECHECK" 2>&1)" && exit_code=0 || exit_code=$?
+  assert_contains "output is NO_WORK" "$output" "NO_WORK"
+
+  test_start "hour 3 inside 22-6"
+  output="$(cd "$REPO_ROOT" && CURRENT_HOUR=3 bash "$PRECHECK" 2>&1)" && exit_code=0 || exit_code=$?
+  assert_contains "output is NO_WORK" "$output" "NO_WORK"
+
+  test_start "hour 22 inside 22-6 (boundary)"
+  output="$(cd "$REPO_ROOT" && CURRENT_HOUR=22 bash "$PRECHECK" 2>&1)" && exit_code=0 || exit_code=$?
+  assert_contains "output is NO_WORK" "$output" "NO_WORK"
+
+  # ── Overnight range: outside active hours ─────────────────────
+
+  echo ""
+  echo -e "${BOLD}Overnight range (22-6): outside${RESET}"
+
+  test_start "hour 10 outside 22-6"
+  output="$(cd "$REPO_ROOT" && CURRENT_HOUR=10 bash "$PRECHECK" 2>&1)" && exit_code=0 || exit_code=$?
+  assert_contains "output is OUTSIDE_ACTIVE_HOURS" "$output" "OUTSIDE_ACTIVE_HOURS"
+
+  test_start "hour 6 outside 22-6 (boundary, end is exclusive)"
+  output="$(cd "$REPO_ROOT" && CURRENT_HOUR=6 bash "$PRECHECK" 2>&1)" && exit_code=0 || exit_code=$?
+  assert_contains "output is OUTSIDE_ACTIVE_HOURS" "$output" "OUTSIDE_ACTIVE_HOURS"
+
+  test_start "hour 15 outside 22-6"
+  output="$(cd "$REPO_ROOT" && CURRENT_HOUR=15 bash "$PRECHECK" 2>&1)" && exit_code=0 || exit_code=$?
+  assert_contains "output is OUTSIDE_ACTIVE_HOURS" "$output" "OUTSIDE_ACTIVE_HOURS"
+
+  # ── Same start and end (always disabled) ──────────────────────
+
+  echo ""
+  echo -e "${BOLD}Same start and end (12-12): always disabled${RESET}"
+
+  echo "${BASE_CONFIG}, \"activeHours\": {\"start\": 12, \"end\": 12}}" > "$REAL_CONFIG"
+
+  test_start "hour 12 outside 12-12"
+  output="$(cd "$REPO_ROOT" && CURRENT_HOUR=12 bash "$PRECHECK" 2>&1)" && exit_code=0 || exit_code=$?
+  assert_contains "output is OUTSIDE_ACTIVE_HOURS" "$output" "OUTSIDE_ACTIVE_HOURS"
+
+  test_start "hour 0 outside 12-12"
+  output="$(cd "$REPO_ROOT" && CURRENT_HOUR=0 bash "$PRECHECK" 2>&1)" && exit_code=0 || exit_code=$?
+  assert_contains "output is OUTSIDE_ACTIVE_HOURS" "$output" "OUTSIDE_ACTIVE_HOURS"
+
+  # ── Active hours + active issue (active issue takes precedence) ─
+
+  echo ""
+  echo -e "${BOLD}Active issue overrides active hours${RESET}"
+
+  # Set hours that would block (9-17, current hour 3 = outside)
+  echo "${BASE_CONFIG}, \"activeHours\": {\"start\": 9, \"end\": 17}}" > "$REAL_CONFIG"
+
+  # But create an active issue file — should still be blocked by hours
+  # because the hours check runs BEFORE the active issue check
+  test_start "outside hours blocks even with active issue"
+  echo "99 200 issue-99-test" > "$RUNTIME_DIR/active-issue-auto.txt"
+  output="$(cd "$REPO_ROOT" && CURRENT_HOUR=3 bash "$PRECHECK" 2>&1)" && exit_code=0 || exit_code=$?
+  assert_contains "output is OUTSIDE_ACTIVE_HOURS" "$output" "OUTSIDE_ACTIVE_HOURS"
+  rm -f "$RUNTIME_DIR/active-issue-auto.txt"
+
+else
+  echo ""
+  echo -e "${YELLOW}Skipping live precheck tests (gh not authenticated)${RESET}"
+fi
+
+echo ""
+test_summary "Active Hours"


### PR DESCRIPTION
## Summary
- Add `activeHours` config field (`{"start": 9, "end": 17}`) to control when scanning is active
- Add `/gh-issue-autopilot hours <start>-<end>` command to configure active hours (and `hours off` to disable)
- Active hours check runs in `precheck.sh` before any API calls or token usage
- Supports normal ranges (9-17), overnight ranges (22-6), and zero-width disable (same start/end)
- 29 new test assertions covering all range types, boundary conditions, and backward compatibility

Closes #1

## Test plan
- [x] All existing tests pass (9 suites, 128 assertions)
- [x] New `test-active-hours.sh` covers config parsing, normal/overnight/zero-width ranges, precheck integration
- [x] Backward compatible: no `activeHours` in config means scanning is always active

🤖 Generated with [Claude Code](https://claude.com/claude-code)