### PR TITLE
Fix #5: Add issue conventions support

### DIFF
--- a/skills/gh-issue-autopilot/SKILL.md
+++ b/skills/gh-issue-autopilot/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: gh-issue-autopilot
-description: Solve GitHub Issues automatically or interactively. No args = autopilot loop (worktree). Issue number = interactive mode. Also supports setup, label config, and stop.
+description: Solve GitHub Issues automatically or interactively. No args = autopilot loop (worktree). Issue number = interactive mode. Also supports setup, label config, issue conventions, and stop.
 model: haiku
 disable-model-invocation: true
 allowed-tools: Bash, Read, Edit, Write, Glob, Grep, Agent, Skill, CronCreate, CronDelete
-argument-hint: "[<issue-number> | stop | setup | label <name> | interval <minutes> | model <name> | hours <start>-<end>]"
+argument-hint: "[<issue-number> | stop | setup | label <name> | interval <minutes> | model <name> | hours <start>-<end> | issue-conventions]"
 ---
 
 # GitHub Issue Autopilot
@@ -21,6 +21,7 @@ Solve GitHub Issues either automatically (loop mode in a worktree) or interactiv
 - `/gh-issue-autopilot interval <minutes>` — Set the scan interval in minutes (default: `5`).
 - `/gh-issue-autopilot model <name>` — Set the model used for implementation subagents (default: `opus`). Accepts: `opus`, `sonnet`, or `haiku`.
 - `/gh-issue-autopilot hours <start>-<end>` — Set active hours for scanning (e.g., `9-17` for 9 AM to 5 PM). Use `hours off` to disable (scan anytime). Supports overnight ranges (e.g., `22-6`).
+- `/gh-issue-autopilot issue-conventions` — Interactively configure issue conventions (label-based scoping rules, title pattern rules). Guides the user through adding, viewing, and removing convention rules.
 
 ## Argument Routing
 
@@ -33,6 +34,7 @@ Parse the argument to determine the mode:
 - `interval ...` → **Interval config** (everything after `interval ` is the number of minutes)
 - `model ...` → **Model config** (everything after `model ` is the model name)
 - `hours ...` → **Hours config** (everything after `hours ` is the range, e.g., `9-17` or `off`)
+- `issue-conventions` → **Issue Conventions config** (interactive configuration of issue convention rules)
 - A number (e.g., `123`) → **Manual mode** for that issue number
 - Anything else → treat as automatic mode
 
@@ -51,11 +53,34 @@ Stored in the repo's `.claude/` directory. Persists across sessions.
   "label": "Claude",
   "interval": 5,
   "model": "opus",
-  "activeHours": { "start": 9, "end": 17 }
+  "activeHours": { "start": 9, "end": 17 },
+  "issueConventions": {
+    "labelRules": [
+      {
+        "label": "security",
+        "action": "extra-scrutiny",
+        "instructions": "Require thorough security review. Check for injection, auth bypass, and data exposure."
+      },
+      {
+        "label": "gh-issue-autopilot",
+        "action": "scope",
+        "instructions": "Scope all work to the skills/gh-issue-autopilot/ directory and its tests."
+      }
+    ],
+    "titleRules": [
+      {
+        "pattern": "^\\[URGENT\\]",
+        "action": "priority",
+        "instructions": "Treat as high priority. Solve before other labeled issues."
+      }
+    ]
+  }
 }
 ```
 
 The `activeHours` field is optional. When omitted, scanning is always active.
+
+The `issueConventions` field is optional. When omitted, no special convention rules are applied. See the **Issue Conventions** section below for details.
 
 ### Runtime state (ephemeral, per-repo)
 
@@ -133,6 +158,62 @@ Controls when scanning is active. Outside active hours, the pre-check script exi
 - Same values (start == end): scanning is effectively disabled (zero-width window).
 - No `activeHours` in config: scanning is always active (default behavior).
 
+### Issue Conventions configuration (`/gh-issue-autopilot issue-conventions`)
+
+Issue conventions let you define rules that change how the autopilot processes issues based on their labels or title patterns. This is useful for:
+- **Scoping work** to specific directories when an issue is tagged with a skill/component label
+- **Adding extra scrutiny** for issues labeled with `security`, `breaking-change`, etc.
+- **Prioritizing issues** whose titles match certain patterns (e.g., `[URGENT]`)
+- **Adding custom instructions** that get passed to the implementation subagent
+
+Convention rules are stored in `.claude/autopilot-config.json` under the `issueConventions` key.
+
+#### Rule types
+
+**Label rules** (`issueConventions.labelRules`): Triggered when an issue has a matching label (case-insensitive match).
+
+Each label rule has:
+- `label` (string, required): The GitHub label name to match.
+- `action` (string, required): One of `scope`, `extra-scrutiny`, `priority`, or `custom`.
+- `instructions` (string, required): Free-text instructions passed to the implementation subagent.
+
+**Title rules** (`issueConventions.titleRules`): Triggered when an issue's title matches a regex pattern.
+
+Each title rule has:
+- `pattern` (string, required): A regex pattern to match against the issue title.
+- `action` (string, required): One of `scope`, `extra-scrutiny`, `priority`, or `custom`.
+- `instructions` (string, required): Free-text instructions passed to the implementation subagent.
+
+#### Actions
+
+- **`scope`**: Restricts the implementation subagent's work to specific directories or files. The `instructions` field should describe the scope (e.g., "Scope all work to the skills/gh-issue-autopilot/ directory and its tests.").
+- **`extra-scrutiny`**: Adds extra review requirements. The `instructions` field describes what to scrutinize (e.g., "Require thorough security review. Check for injection, auth bypass, and data exposure.").
+- **`priority`**: Marks the issue as high priority. When multiple labeled issues exist, priority issues are solved first. The `instructions` field can add context.
+- **`custom`**: A catch-all for any other convention. The `instructions` are passed directly to the subagent.
+
+#### Applying conventions during scanning
+
+When triage picks up an issue (Step 1 of Scanning), before launching the implementation subagent:
+
+1. Read `issueConventions` from `.claude/autopilot-config.json`.
+2. Fetch the issue's labels: `gh issue view <NUMBER> --json labels --jq '.labels[].name'`
+3. For each label rule, check if the issue has a matching label (case-insensitive). Collect all matching rules.
+4. For each title rule, check if the issue title matches the regex pattern. Collect all matching rules.
+5. If any `priority` rules match and there are multiple candidate issues, prefer priority issues.
+6. Concatenate the `instructions` from all matching rules into an `## Issue Conventions` section and include it in the subagent prompt. This gives the subagent specific guidance for this issue.
+
+#### Interactive configuration
+
+When the user runs `/gh-issue-autopilot issue-conventions`, present the current conventions (if any) and offer these options:
+
+1. **View current rules** — Display all label rules and title rules in a readable format.
+2. **Add a label rule** — Ask for: label name, action (scope/extra-scrutiny/priority/custom), instructions.
+3. **Add a title rule** — Ask for: regex pattern, action, instructions.
+4. **Remove a rule** — List all rules with indices and ask which to remove.
+5. **Done** — Exit the configuration.
+
+After each add/remove, write the updated config back to `.claude/autopilot-config.json`.
+
 ---
 
 ## Setup (`/gh-issue-autopilot setup`)
@@ -154,6 +235,7 @@ Run these checks and report pass/fail for each:
 9. **Scan interval**: Read from `.claude/autopilot-config.json` or show default (`5` minutes)
 10. **Implementation model**: Read from `.claude/autopilot-config.json` or show default (`opus`). This is the model used for subagents that solve issues and address reviews. Explain that the skill runs on Haiku for triage and only escalates to this model for implementation. Ask the user if they'd like to change it (options: `opus`, `sonnet`, `haiku`).
 11. **Active hours**: Read from `.claude/autopilot-config.json`. If `activeHours` is set, show the configured range (e.g., `9-17`). If not set, show "always active (no restriction)". Ask the user if they'd like to configure active hours.
+12. **Issue conventions**: Read from `.claude/autopilot-config.json`. If `issueConventions` is set, show the number of label rules and title rules configured. If not set, show "no issue conventions configured". Offer to run `/gh-issue-autopilot issue-conventions` to configure them. Briefly explain that issue conventions let you add label-based scoping rules (e.g., tag issues with a skill label to restrict work to that skill's directory) and title-pattern rules (e.g., `[URGENT]` prefix for priority).
 
 ### Step 2: Check CLAUDE.md
 
@@ -162,6 +244,7 @@ Read the project's `CLAUDE.md` (if it exists) and check for sections that enhanc
 1. **Testing section** — Should document how to run the full test suite (command or script). Look for headings like `## Testing`, `## Running Tests`, `### Running All Tests`, or content containing `test` commands.
 2. **PR conventions** — Should document how PRs should be formatted (title style, body template). Look for headings like `## PR`, `## Pull Request`, or content mentioning PR format/template.
 3. **Git workflow** — Should document the main branch name and branching conventions. Look for headings like `## Git`, `## Workflow`, `## Branch`.
+4. **Issue conventions** — Should document how issues should be labeled, titled, or categorized for this project. Look for headings like `## Issue`, `## Issue Convention`, or content mentioning issue labels, issue templates, or issue triage. This section helps the autopilot understand project-specific issue handling rules.
 
 ### Step 3: Offer to help
 
@@ -170,8 +253,9 @@ For any missing CLAUDE.md sections, **offer to help the user write them**. If th
 - **Testing section**: Ask what commands run the test suite, then write a `## Testing` section with a `### Running All Tests` subsection containing the command(s).
 - **PR conventions**: Ask about their preferred PR title/body style, then write a `## Pull Requests` section.
 - **Git workflow**: Detect the default branch and write a `## Git Workflow` section documenting it.
+- **Issue conventions**: Ask how the user wants issues to be categorized (e.g., labels per skill/component, priority labels, special title prefixes). Then write a `## Issue Conventions` section documenting the rules. Also offer to configure matching `issueConventions` rules in `.claude/autopilot-config.json` so the autopilot enforces them automatically.
 
-If `CLAUDE.md` doesn't exist at all, offer to create one with all three sections.
+If `CLAUDE.md` doesn't exist at all, offer to create one with all sections.
 
 Always show the user what you plan to write and get approval before modifying CLAUDE.md.
 
@@ -238,8 +322,10 @@ This skill runs on Haiku to keep scanning costs low. Perform the triage directly
 
 When triage identifies work that requires code changes (`SOLVE` or `ADDRESS_REVIEWS`), read the `model` field from `.claude/autopilot-config.json` (default: `opus`). Launch a subagent using the Agent tool with that model. This is the only phase that uses the more capable model.
 
-- **`ADDRESS_REVIEWS`** — Launch the subagent with a prompt to: check out the PR branch in a worktree, read the review comments, address them, commit, and push. Include the PR number, branch name, and a summary of the review feedback in the prompt. Then stop.
-- **`SOLVE`** — Launch the subagent with a prompt to work on the issue **inside a worktree**. Include the issue number, title, body, the default branch name, and `REPO_ID` in the prompt. The agent should:
+**Before launching the subagent**, apply issue conventions (see "Applying conventions during scanning" in the Issue Conventions section above). If any convention rules match the issue, include the collected instructions in the subagent prompt under an `## Issue Conventions` heading. This ensures the subagent respects scoping rules, extra scrutiny requirements, and any other project-specific conventions.
+
+- **`ADDRESS_REVIEWS`** — Launch the subagent with a prompt to: check out the PR branch in a worktree, read the review comments, address them, commit, and push. Include the PR number, branch name, and a summary of the review feedback in the prompt. Also include any applicable issue convention instructions. Then stop.
+- **`SOLVE`** — Launch the subagent with a prompt to work on the issue **inside a worktree**. Include the issue number, title, body, the default branch name, `REPO_ID`, and any applicable issue convention instructions in the prompt. The agent should:
    a. Create a worktree: `git worktree add /tmp/autopilot-worktree-${REPO_ID} -b issue-<NUMBER>-<short-description> $DEFAULT_BRANCH`
    b. All subsequent work (reading code, editing, building, testing) happens in the worktree
    c. Implement the fix (read code, understand the problem, write the solution, write tests)

--- a/tests/gh-issue-autopilot/test-issue-conventions.sh
+++ b/tests/gh-issue-autopilot/test-issue-conventions.sh
@@ -1,0 +1,576 @@
+#!/usr/bin/env bash
+# Tests for issue conventions configuration in autopilot-config.json
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../helpers.sh"
+
+echo -e "${BOLD}gh-issue-autopilot: Issue Conventions${RESET}"
+echo ""
+
+# Use a temp directory to simulate a repo's .claude/ dir
+TEMP_DIR="$(mktemp -d)"
+CONFIG_DIR="$TEMP_DIR/.claude"
+CONFIG_FILE="$CONFIG_DIR/autopilot-config.json"
+trap 'cleanup_temp "$TEMP_DIR"' EXIT
+
+# ══════════════════════════════════════════════════════════════════
+# Helper functions (mirror the logic the skill would use)
+# ══════════════════════════════════════════════════════════════════
+
+# Get the number of label rules configured
+get_label_rules_count() {
+  local cfg="$1"
+  if [ -f "$cfg" ]; then
+    # Extract labelRules array and count entries by counting "label" keys
+    local count
+    count="$(grep -o '"label"[[:space:]]*:' "$cfg" 2>/dev/null | wc -l || echo 0)"
+    # Subtract 1 for the top-level "label" key if it exists
+    local has_top_label
+    has_top_label="$(grep -c '"label"[[:space:]]*:[[:space:]]*"[^"]*"' "$cfg" 2>/dev/null || echo 0)"
+    # The top-level label has a string value, labelRules labels also have string values
+    # We need a better approach: count entries inside labelRules array
+    # Use python-free approach: count occurrences of "action" inside the file
+    # since only rule objects have "action" fields
+    # But title rules also have action. So count all actions.
+    # Better: parse with grep for label rules specifically
+    echo "$count"
+  else
+    echo "0"
+  fi
+}
+
+# Read label rules as lines of "label|action|instructions"
+get_label_rules() {
+  local cfg="$1"
+  if [ ! -f "$cfg" ]; then
+    return
+  fi
+  # Simple extraction: find labelRules entries
+  # Each rule has label, action, instructions
+  # Use a state machine approach with grep
+  local in_label_rules=false
+  local brace_depth=0
+  local current_label="" current_action="" current_instructions=""
+
+  while IFS= read -r line; do
+    if echo "$line" | grep -q '"labelRules"'; then
+      in_label_rules=true
+      continue
+    fi
+    if [ "$in_label_rules" = true ]; then
+      # Check for end of labelRules array
+      if echo "$line" | grep -q '^\s*\]'; then
+        in_label_rules=false
+        continue
+      fi
+      # Extract fields
+      local label_match action_match instr_match
+      label_match="$(echo "$line" | grep -o '"label"[[:space:]]*:[[:space:]]*"[^"]*"' | sed 's/.*"label"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/' || true)"
+      action_match="$(echo "$line" | grep -o '"action"[[:space:]]*:[[:space:]]*"[^"]*"' | sed 's/.*"action"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/' || true)"
+      instr_match="$(echo "$line" | grep -o '"instructions"[[:space:]]*:[[:space:]]*"[^"]*"' | sed 's/.*"instructions"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/' || true)"
+
+      [ -n "$label_match" ] && current_label="$label_match"
+      [ -n "$action_match" ] && current_action="$action_match"
+      [ -n "$instr_match" ] && current_instructions="$instr_match"
+
+      # If we have all three, output and reset
+      if [ -n "$current_label" ] && [ -n "$current_action" ] && [ -n "$current_instructions" ]; then
+        echo "${current_label}|${current_action}|${current_instructions}"
+        current_label="" current_action="" current_instructions=""
+      fi
+    fi
+  done < "$cfg"
+}
+
+# Read title rules as lines of "pattern<TAB>action<TAB>instructions"
+# Uses TAB as delimiter since patterns may contain pipe characters
+get_title_rules() {
+  local cfg="$1"
+  if [ ! -f "$cfg" ]; then
+    return
+  fi
+  local in_title_rules=false
+  local current_pattern="" current_action="" current_instructions=""
+
+  while IFS= read -r line; do
+    if echo "$line" | grep -q '"titleRules"'; then
+      in_title_rules=true
+      continue
+    fi
+    if [ "$in_title_rules" = true ]; then
+      if echo "$line" | grep -q '^\s*\]'; then
+        in_title_rules=false
+        continue
+      fi
+      local pattern_match action_match instr_match
+      pattern_match="$(echo "$line" | grep -o '"pattern"[[:space:]]*:[[:space:]]*"[^"]*"' | sed 's/.*"pattern"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/' || true)"
+      action_match="$(echo "$line" | grep -o '"action"[[:space:]]*:[[:space:]]*"[^"]*"' | sed 's/.*"action"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/' || true)"
+      instr_match="$(echo "$line" | grep -o '"instructions"[[:space:]]*:[[:space:]]*"[^"]*"' | sed 's/.*"instructions"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/' || true)"
+
+      [ -n "$pattern_match" ] && current_pattern="$pattern_match"
+      [ -n "$action_match" ] && current_action="$action_match"
+      [ -n "$instr_match" ] && current_instructions="$instr_match"
+
+      if [ -n "$current_pattern" ] && [ -n "$current_action" ] && [ -n "$current_instructions" ]; then
+        printf '%s\t%s\t%s\n' "$current_pattern" "$current_action" "$current_instructions"
+        current_pattern="" current_action="" current_instructions=""
+      fi
+    fi
+  done < "$cfg"
+}
+
+# Check if issueConventions exists in config
+has_issue_conventions() {
+  local cfg="$1"
+  if [ -f "$cfg" ] && grep -q '"issueConventions"' "$cfg" 2>/dev/null; then
+    echo "true"
+  else
+    echo "false"
+  fi
+}
+
+# Match label rules against an issue's labels (case-insensitive)
+# Args: config_file label1 label2 ...
+match_label_rules() {
+  local cfg="$1"
+  shift
+  local issue_labels=("$@")
+  local rules
+  rules="$(get_label_rules "$cfg")"
+
+  while IFS='|' read -r rule_label rule_action rule_instructions; do
+    [ -z "$rule_label" ] && continue
+    local lower_rule_label
+    lower_rule_label="$(echo "$rule_label" | tr '[:upper:]' '[:lower:]')"
+    for issue_label in "${issue_labels[@]}"; do
+      local lower_issue_label
+      lower_issue_label="$(echo "$issue_label" | tr '[:upper:]' '[:lower:]')"
+      if [ "$lower_rule_label" = "$lower_issue_label" ]; then
+        echo "${rule_action}|${rule_instructions}"
+      fi
+    done
+  done <<< "$rules"
+}
+
+# Match title rules against an issue title
+# Args: config_file "issue title"
+match_title_rules() {
+  local cfg="$1"
+  local title="$2"
+  local rules
+  rules="$(get_title_rules "$cfg")"
+
+  while IFS=$'\t' read -r rule_pattern rule_action rule_instructions; do
+    [ -z "$rule_pattern" ] && continue
+    # Unescape JSON double-backslashes to single backslashes for regex
+    local unescaped_pattern
+    unescaped_pattern="$(echo "$rule_pattern" | sed 's/\\\\/\\/g')"
+    if echo "$title" | grep -qE "$unescaped_pattern"; then
+      echo "${rule_action}|${rule_instructions}"
+    fi
+  done <<< "$rules"
+}
+
+# ══════════════════════════════════════════════════════════════════
+# Tests: No config / empty config
+# ══════════════════════════════════════════════════════════════════
+
+echo -e "${BOLD}── No Config File ──${RESET}"
+echo ""
+
+test_start "no config file"
+assert_equals "no config means no conventions" "false" "$(has_issue_conventions "$CONFIG_FILE")"
+
+rules="$(get_label_rules "$CONFIG_FILE")"
+assert_equals "no label rules from missing config" "" "$rules"
+
+rules="$(get_title_rules "$CONFIG_FILE")"
+assert_equals "no title rules from missing config" "" "$rules"
+
+echo ""
+echo -e "${BOLD}── Empty Config ──${RESET}"
+echo ""
+
+mkdir -p "$CONFIG_DIR"
+echo '{"label": "Claude"}' > "$CONFIG_FILE"
+
+test_start "config without issueConventions"
+assert_equals "no conventions in basic config" "false" "$(has_issue_conventions "$CONFIG_FILE")"
+
+# ══════════════════════════════════════════════════════════════════
+# Tests: Config with label rules
+# ══════════════════════════════════════════════════════════════════
+
+echo ""
+echo -e "${BOLD}── Label Rules ──${RESET}"
+echo ""
+
+cat > "$CONFIG_FILE" << 'JSONEOF'
+{
+  "label": "Claude",
+  "issueConventions": {
+    "labelRules": [
+      {
+        "label": "security",
+        "action": "extra-scrutiny",
+        "instructions": "Require thorough security review."
+      },
+      {
+        "label": "gh-issue-autopilot",
+        "action": "scope",
+        "instructions": "Scope work to skills/gh-issue-autopilot/ directory."
+      }
+    ],
+    "titleRules": []
+  }
+}
+JSONEOF
+
+test_start "has issue conventions"
+assert_equals "conventions present" "true" "$(has_issue_conventions "$CONFIG_FILE")"
+
+test_start "reads label rules"
+rules="$(get_label_rules "$CONFIG_FILE")"
+line_count="$(echo "$rules" | grep -c '.' || true)"
+assert_equals "two label rules found" "2" "$line_count"
+
+test_start "first label rule content"
+first_rule="$(echo "$rules" | head -1)"
+assert_contains "first rule has security label" "$first_rule" "security"
+assert_contains "first rule has extra-scrutiny action" "$first_rule" "extra-scrutiny"
+assert_contains "first rule has instructions" "$first_rule" "security review"
+
+test_start "second label rule content"
+second_rule="$(echo "$rules" | tail -1)"
+assert_contains "second rule has autopilot label" "$second_rule" "gh-issue-autopilot"
+assert_contains "second rule has scope action" "$second_rule" "scope"
+
+# ══════════════════════════════════════════════════════════════════
+# Tests: Config with title rules
+# ══════════════════════════════════════════════════════════════════
+
+echo ""
+echo -e "${BOLD}── Title Rules ──${RESET}"
+echo ""
+
+cat > "$CONFIG_FILE" << 'JSONEOF'
+{
+  "label": "Claude",
+  "issueConventions": {
+    "labelRules": [],
+    "titleRules": [
+      {
+        "pattern": "^\\[URGENT\\]",
+        "action": "priority",
+        "instructions": "Treat as high priority."
+      },
+      {
+        "pattern": "^\\[RFC\\]",
+        "action": "custom",
+        "instructions": "This is a request for comments, not a direct implementation task."
+      }
+    ]
+  }
+}
+JSONEOF
+
+test_start "reads title rules"
+rules="$(get_title_rules "$CONFIG_FILE")"
+line_count="$(echo "$rules" | grep -c '.' || true)"
+assert_equals "two title rules found" "2" "$line_count"
+
+test_start "first title rule content"
+first_rule="$(echo "$rules" | head -1)"
+assert_contains "first rule has URGENT pattern" "$first_rule" "URGENT"
+assert_contains "first rule has priority action" "$first_rule" "priority"
+
+test_start "second title rule content"
+second_rule="$(echo "$rules" | tail -1)"
+assert_contains "second rule has RFC pattern" "$second_rule" "RFC"
+assert_contains "second rule has custom action" "$second_rule" "custom"
+
+# ══════════════════════════════════════════════════════════════════
+# Tests: Label matching (case-insensitive)
+# ══════════════════════════════════════════════════════════════════
+
+echo ""
+echo -e "${BOLD}── Label Matching ──${RESET}"
+echo ""
+
+cat > "$CONFIG_FILE" << 'JSONEOF'
+{
+  "label": "Claude",
+  "issueConventions": {
+    "labelRules": [
+      {
+        "label": "Security",
+        "action": "extra-scrutiny",
+        "instructions": "Check for vulnerabilities."
+      },
+      {
+        "label": "gh-issue-autopilot",
+        "action": "scope",
+        "instructions": "Scope to autopilot skill."
+      }
+    ],
+    "titleRules": []
+  }
+}
+JSONEOF
+
+test_start "exact label match"
+matches="$(match_label_rules "$CONFIG_FILE" "Security")"
+assert_contains "matches Security label" "$matches" "extra-scrutiny"
+
+test_start "case-insensitive label match"
+matches="$(match_label_rules "$CONFIG_FILE" "security")"
+assert_contains "matches security (lowercase)" "$matches" "extra-scrutiny"
+
+test_start "no match for unrelated label"
+matches="$(match_label_rules "$CONFIG_FILE" "bug")"
+assert_equals "no match for bug label" "" "$matches"
+
+test_start "multiple labels, one matches"
+matches="$(match_label_rules "$CONFIG_FILE" "bug" "security" "enhancement")"
+match_count="$(echo "$matches" | grep -c '.' || true)"
+assert_equals "one match from multiple labels" "1" "$match_count"
+
+test_start "multiple labels, multiple matches"
+matches="$(match_label_rules "$CONFIG_FILE" "security" "gh-issue-autopilot")"
+match_count="$(echo "$matches" | grep -c '.' || true)"
+assert_equals "two matches from matching labels" "2" "$match_count"
+
+# ══════════════════════════════════════════════════════════════════
+# Tests: Title matching
+# ══════════════════════════════════════════════════════════════════
+
+echo ""
+echo -e "${BOLD}── Title Matching ──${RESET}"
+echo ""
+
+cat > "$CONFIG_FILE" << 'JSONEOF'
+{
+  "label": "Claude",
+  "issueConventions": {
+    "labelRules": [],
+    "titleRules": [
+      {
+        "pattern": "^\\[URGENT\\]",
+        "action": "priority",
+        "instructions": "High priority issue."
+      },
+      {
+        "pattern": "security|vulnerability",
+        "action": "extra-scrutiny",
+        "instructions": "Security-related title."
+      }
+    ]
+  }
+}
+JSONEOF
+
+test_start "title matches URGENT pattern"
+matches="$(match_title_rules "$CONFIG_FILE" "[URGENT] Fix login crash")"
+assert_contains "matches URGENT prefix" "$matches" "priority"
+
+test_start "title does not match URGENT in middle"
+matches="$(match_title_rules "$CONFIG_FILE" "Fix URGENT login crash")"
+# The pattern is ^\\[URGENT\\], so URGENT in the middle should NOT match
+# But the second rule might match if "security" appears
+assert_not_contains "no priority match for non-prefix" "$matches" "priority"
+
+test_start "title matches security keyword"
+matches="$(match_title_rules "$CONFIG_FILE" "Fix security vulnerability in auth")"
+assert_contains "matches security keyword" "$matches" "extra-scrutiny"
+
+test_start "title matches vulnerability keyword"
+matches="$(match_title_rules "$CONFIG_FILE" "Patch vulnerability in API")"
+assert_contains "matches vulnerability keyword" "$matches" "extra-scrutiny"
+
+test_start "title with no matching pattern"
+matches="$(match_title_rules "$CONFIG_FILE" "Add new feature for dashboard")"
+assert_equals "no matches for unrelated title" "" "$matches"
+
+# ══════════════════════════════════════════════════════════════════
+# Tests: Combined label + title rules
+# ══════════════════════════════════════════════════════════════════
+
+echo ""
+echo -e "${BOLD}── Combined Rules ──${RESET}"
+echo ""
+
+cat > "$CONFIG_FILE" << 'JSONEOF'
+{
+  "label": "Claude",
+  "issueConventions": {
+    "labelRules": [
+      {
+        "label": "gh-issue-autopilot",
+        "action": "scope",
+        "instructions": "Scope to autopilot."
+      }
+    ],
+    "titleRules": [
+      {
+        "pattern": "^\\[URGENT\\]",
+        "action": "priority",
+        "instructions": "High priority."
+      }
+    ]
+  }
+}
+JSONEOF
+
+test_start "both label and title match"
+label_matches="$(match_label_rules "$CONFIG_FILE" "gh-issue-autopilot")"
+title_matches="$(match_title_rules "$CONFIG_FILE" "[URGENT] Fix autopilot bug")"
+assert_contains "label rule matches" "$label_matches" "scope"
+assert_contains "title rule matches" "$title_matches" "priority"
+
+# Combine instructions (as the skill would do)
+all_instructions=""
+while IFS='|' read -r action instructions; do
+  [ -n "$instructions" ] && all_instructions="${all_instructions}${instructions} "
+done <<< "$label_matches"
+while IFS='|' read -r action instructions; do
+  [ -n "$instructions" ] && all_instructions="${all_instructions}${instructions} "
+done <<< "$title_matches"
+
+test_start "combined instructions"
+assert_contains "combined has scope instruction" "$all_instructions" "Scope to autopilot"
+assert_contains "combined has priority instruction" "$all_instructions" "High priority"
+
+# ══════════════════════════════════════════════════════════════════
+# Tests: Empty issueConventions
+# ══════════════════════════════════════════════════════════════════
+
+echo ""
+echo -e "${BOLD}── Empty Issue Conventions ──${RESET}"
+echo ""
+
+cat > "$CONFIG_FILE" << 'JSONEOF'
+{
+  "label": "Claude",
+  "issueConventions": {
+    "labelRules": [],
+    "titleRules": []
+  }
+}
+JSONEOF
+
+test_start "empty conventions"
+assert_equals "conventions present but empty" "true" "$(has_issue_conventions "$CONFIG_FILE")"
+
+rules="$(get_label_rules "$CONFIG_FILE")"
+assert_equals "no label rules" "" "$rules"
+
+rules="$(get_title_rules "$CONFIG_FILE")"
+assert_equals "no title rules" "" "$rules"
+
+# ══════════════════════════════════════════════════════════════════
+# Tests: Config with only issueConventions (no other fields affected)
+# ══════════════════════════════════════════════════════════════════
+
+echo ""
+echo -e "${BOLD}── Conventions alongside other config ──${RESET}"
+echo ""
+
+cat > "$CONFIG_FILE" << 'JSONEOF'
+{
+  "label": "bot-ready",
+  "interval": 10,
+  "model": "sonnet",
+  "activeHours": {"start": 9, "end": 17},
+  "issueConventions": {
+    "labelRules": [
+      {
+        "label": "frontend",
+        "action": "scope",
+        "instructions": "Scope to src/frontend/ directory."
+      }
+    ],
+    "titleRules": [
+      {
+        "pattern": "^\\[WIP\\]",
+        "action": "custom",
+        "instructions": "Skip this issue, it is work in progress."
+      }
+    ]
+  }
+}
+JSONEOF
+
+test_start "conventions alongside other config"
+# Verify other config fields are unaffected
+label="$(grep -o '"label"[[:space:]]*:[[:space:]]*"[^"]*"' "$CONFIG_FILE" | head -1 | sed 's/.*"label"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/')"
+assert_equals "label field intact" "bot-ready" "$label"
+
+interval="$(grep -o '"interval"[[:space:]]*:[[:space:]]*[0-9]\+' "$CONFIG_FILE" | head -1 | sed 's/.*"interval"[[:space:]]*:[[:space:]]*//')"
+assert_equals "interval field intact" "10" "$interval"
+
+# And conventions still work
+assert_equals "conventions still present" "true" "$(has_issue_conventions "$CONFIG_FILE")"
+label_rules="$(get_label_rules "$CONFIG_FILE")"
+assert_contains "frontend rule present" "$label_rules" "frontend"
+
+title_rules="$(get_title_rules "$CONFIG_FILE")"
+assert_contains "WIP rule present" "$title_rules" "WIP"
+
+# ══════════════════════════════════════════════════════════════════
+# Tests: Action types
+# ══════════════════════════════════════════════════════════════════
+
+echo ""
+echo -e "${BOLD}── Action Types ──${RESET}"
+echo ""
+
+cat > "$CONFIG_FILE" << 'JSONEOF'
+{
+  "label": "Claude",
+  "issueConventions": {
+    "labelRules": [
+      {
+        "label": "scope-test",
+        "action": "scope",
+        "instructions": "Scope instructions."
+      },
+      {
+        "label": "scrutiny-test",
+        "action": "extra-scrutiny",
+        "instructions": "Scrutiny instructions."
+      },
+      {
+        "label": "priority-test",
+        "action": "priority",
+        "instructions": "Priority instructions."
+      },
+      {
+        "label": "custom-test",
+        "action": "custom",
+        "instructions": "Custom instructions."
+      }
+    ],
+    "titleRules": []
+  }
+}
+JSONEOF
+
+test_start "scope action"
+matches="$(match_label_rules "$CONFIG_FILE" "scope-test")"
+assert_contains "scope action found" "$matches" "scope"
+
+test_start "extra-scrutiny action"
+matches="$(match_label_rules "$CONFIG_FILE" "scrutiny-test")"
+assert_contains "extra-scrutiny action found" "$matches" "extra-scrutiny"
+
+test_start "priority action"
+matches="$(match_label_rules "$CONFIG_FILE" "priority-test")"
+assert_contains "priority action found" "$matches" "priority"
+
+test_start "custom action"
+matches="$(match_label_rules "$CONFIG_FILE" "custom-test")"
+assert_contains "custom action found" "$matches" "custom"
+
+echo ""
+test_summary "Issue Conventions"


### PR DESCRIPTION
## Summary

- Added `issueConventions` configuration to `autopilot-config.json` supporting label-based rules (scope, extra-scrutiny, priority, custom) and title-pattern rules with regex matching
- Added `/gh-issue-autopilot issue-conventions` command for interactive configuration of convention rules
- Added issue conventions to the setup checklist (Step 1 item 12) and CLAUDE.md checks (Step 2 item 4)
- Updated scanning/implementation to apply matching convention rules as instructions passed to subagents
- Added 42-assertion test suite covering config parsing, label matching (case-insensitive), title matching (regex), combined rules, action types, and coexistence with other config fields

Closes #5

## Test plan

- [x] Run `./tests/run-tests.sh` — all 10 suites pass
- [x] Verify new `test-issue-conventions.sh` covers: no config, empty config, label rules, title rules, case-insensitive label matching, regex title matching, combined label+title rules, empty conventions, conventions alongside other config, all four action types
- [x] Verify existing tests still pass (no regressions)
- [ ] Manual test: run `/gh-issue-autopilot setup` and verify issue conventions appear in the checklist
- [ ] Manual test: run `/gh-issue-autopilot issue-conventions` to add/view/remove rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)