### PR TITLE
Fix #8: Detect inline PR review comments during scan triage

### DIFF
--- a/skills/gh-issue-autopilot/SKILL.md
+++ b/skills/gh-issue-autopilot/SKILL.md
@@ -223,8 +223,13 @@ This skill runs on Haiku to keep scanning costs low. Perform the triage directly
 4. Check if there is already an active issue being worked on. Check **both** `$RUNTIME_DIR/active-issue-auto.txt` and `$RUNTIME_DIR/active-issue-manual.txt`. If either exists, read it and check the PR:
    - Run `gh pr view <PR_NUMBER> --json state,reviews,comments` to check the PR.
    - **IMPORTANT: You MUST examine the `reviews` and `comments` arrays in the response.** Do not just check `state`. Look for comments or reviews authored by someone other than yourself that arrived after your last comment. Any such comment means there is feedback to address.
+   - **Also check for inline review comments** (comments left on specific lines of code). These are NOT included in the `reviews` or `comments` fields above. Fetch them separately:
+     ```
+     gh api repos/{owner}/{repo}/pulls/{pr}/comments --jq '[.[] | select(.user.login != "<YOUR_LOGIN>" and .user.type != "Bot")] | length'
+     ```
+     Replace `{owner}/{repo}` with the repo's owner/name (from `gh repo view --json owner,name --jq '.owner.login + "/" + .name'`) and `{pr}` with the PR number. If the count is greater than zero, there are inline review comments from reviewers that need to be addressed.
    - If the PR is **merged**: proceed to **After Merge** cleanup (see below). If it was `active-issue-auto.txt`, loop back to step 5 to check for the next issue. If it was `active-issue-manual.txt`, stop after cleanup.
-   - If the PR is **still open with unaddressed review comments or PR comments**: proceed to **Step 2** with action `ADDRESS_REVIEWS`. Pass the PR number, branch name, and the content of the comments to the subagent.
+   - If the PR is **still open with unaddressed review comments, PR comments, or inline review comments**: proceed to **Step 2** with action `ADDRESS_REVIEWS`. Pass the PR number, branch name, and the content of the comments (including inline comments) to the subagent.
    - If the PR is **still open with no new comments to address**: say "PR still open, no action needed." and **stop**. Do not pick up another issue.
 5. If no active issue (neither file exists), scan for the next issue to work on:
    ```
@@ -238,7 +243,7 @@ This skill runs on Haiku to keep scanning costs low. Perform the triage directly
 
 When triage identifies work that requires code changes (`SOLVE` or `ADDRESS_REVIEWS`), read the `model` field from `.claude/autopilot-config.json` (default: `opus`). Launch a subagent using the Agent tool with that model. This is the only phase that uses the more capable model.
 
-- **`ADDRESS_REVIEWS`** — Launch the subagent with a prompt to: check out the PR branch in a worktree, read the review comments, address them, commit, and push. Include the PR number, branch name, and a summary of the review feedback in the prompt. Then stop.
+- **`ADDRESS_REVIEWS`** — Launch the subagent with a prompt to: check out the PR branch in a worktree, read the review comments (including inline review comments from `gh api repos/{owner}/{repo}/pulls/{pr}/comments`), address them, commit, and push. Include the PR number, branch name, and a summary of the review feedback in the prompt. Then stop.
 - **`SOLVE`** — Launch the subagent with a prompt to work on the issue **inside a worktree**. Include the issue number, title, body, the default branch name, and `REPO_ID` in the prompt. The agent should:
    a. Create a worktree: `git worktree add /tmp/autopilot-worktree-${REPO_ID} -b issue-<NUMBER>-<short-description> $DEFAULT_BRANCH`
    b. All subsequent work (reading code, editing, building, testing) happens in the worktree

--- a/tests/gh-issue-autopilot/test-scan-inline-comments.sh
+++ b/tests/gh-issue-autopilot/test-scan-inline-comments.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Tests that SKILL.md documents inline review comment detection during scan triage
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../helpers.sh"
+
+SKILL_FILE="$REPO_ROOT/skills/gh-issue-autopilot/SKILL.md"
+
+echo -e "${BOLD}gh-issue-autopilot: Inline Review Comment Detection${RESET}"
+echo ""
+
+# ── SKILL.md documents inline review comment fetching ─────────────
+
+echo -e "${BOLD}SKILL.md scan triage documentation${RESET}"
+
+SKILL_CONTENT="$(cat "$SKILL_FILE")"
+
+test_start "documents inline review comment API endpoint"
+assert_contains \
+  "mentions pulls/{pr}/comments API endpoint" \
+  "$SKILL_CONTENT" \
+  "pulls/{pr}/comments"
+
+test_start "documents that inline comments are separate from reviews/comments"
+assert_contains \
+  "notes inline comments are NOT in reviews or comments fields" \
+  "$SKILL_CONTENT" \
+  "NOT included in the \`reviews\` or \`comments\` fields"
+
+test_start "documents filtering out bot's own inline comments"
+assert_contains \
+  "filters out Bot user type" \
+  "$SKILL_CONTENT" \
+  '.user.type != "Bot"'
+
+test_start "documents filtering out own login for inline comments"
+assert_contains \
+  "filters out own login" \
+  "$SKILL_CONTENT" \
+  ".user.login"
+
+test_start "inline comments trigger ADDRESS_REVIEWS"
+assert_contains \
+  "inline review comments trigger ADDRESS_REVIEWS" \
+  "$SKILL_CONTENT" \
+  "inline review comments"
+
+test_start "ADDRESS_REVIEWS subagent reads inline comments"
+assert_contains \
+  "ADDRESS_REVIEWS prompt includes inline review comments" \
+  "$SKILL_CONTENT" \
+  "including inline review comments"
+
+echo ""
+test_summary "Inline Review Comment Detection"


### PR DESCRIPTION
## Summary

- Adds inline review comment detection to the scan triage logic in SKILL.md
- The scan now fetches `gh api repos/{owner}/{repo}/pulls/{pr}/comments` to find code-level review comments that are not included in the standard `reviews` or `comments` fields from `gh pr view`
- Filters out bot and self-authored inline comments to avoid false positives
- Inline comments from reviewers trigger `ADDRESS_REVIEWS` just like regular review comments

Closes #8

## Test plan

- [x] New test file `test-scan-inline-comments.sh` validates SKILL.md documents the inline comment API endpoint, bot filtering, and ADDRESS_REVIEWS triggering
- [x] All 10 existing test suites continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)