### PR TITLE
Fix #15: precheck.sh returns exit 0 for no-work conditions

### DIFF
--- a/skills/gh-issue-autopilot/SKILL.md
+++ b/skills/gh-issue-autopilot/SKILL.md
@@ -216,8 +216,10 @@ Run the pre-check script as the very first action. This avoids burning tokens on
 ```bash
 bash "$(dirname "$(readlink -f ~/.claude/skills/gh-issue-autopilot/SKILL.md)")/precheck.sh"
 ```
-- If it exits **non-zero**: say "No work found." and **stop immediately**. Do not run any other commands. This also covers active hours — if the current time is outside configured active hours, the pre-check exits non-zero with `OUTSIDE_ACTIVE_HOURS`.
-- If it exits **zero**: proceed with the cron renewal check and then triage below.
+- If it exits **non-zero**: an unexpected error occurred. Log the error and **stop immediately**.
+- If it exits **zero**, check the output string:
+  - `NO_WORK` or `OUTSIDE_ACTIVE_HOURS`: say "No work found." and **stop immediately**. Do not run any other commands.
+  - `ACTIVE_ISSUE:*` or `ISSUES_FOUND:*`: proceed with the cron renewal check and then triage below.
 
 **Step 0.5 — Cron Validation & Renewal (keeps autopilot running beyond 3 days):**
 

--- a/skills/gh-issue-autopilot/precheck.sh
+++ b/skills/gh-issue-autopilot/precheck.sh
@@ -1,7 +1,12 @@
 #!/usr/bin/env bash
 # Pre-check for gh-issue-autopilot scan.
 # Runs before the full scan to avoid unnecessary Claude token usage.
-# Exit 0 = work to do (proceed with scan), exit 1 = no work (skip scan).
+# Always exits 0 on success. The output string indicates the result:
+#   OUTSIDE_ACTIVE_HOURS — skip scan (outside configured hours)
+#   ACTIVE_ISSUE:<mode>  — work to do (PR monitoring needed)
+#   ISSUES_FOUND:<count> — work to do (new issues to pick up)
+#   NO_WORK              — skip scan (nothing to do)
+# A non-zero exit indicates an unexpected error (e.g., gh CLI failure).
 #
 # Checks:
 # 0. If outside configured active hours → no work (skip before any API calls)
@@ -26,18 +31,18 @@ if [ -f "$CONFIG_FILE" ]; then
     if [ "$AH_START" -eq "$AH_END" ]; then
       # Zero-width window: always outside
       echo "OUTSIDE_ACTIVE_HOURS"
-      exit 1
+      exit 0
     elif [ "$AH_START" -lt "$AH_END" ]; then
       # Normal range (e.g., 9-17)
       if [ "$HOUR" -lt "$AH_START" ] || [ "$HOUR" -ge "$AH_END" ]; then
         echo "OUTSIDE_ACTIVE_HOURS"
-        exit 1
+        exit 0
       fi
     else
       # Overnight range (e.g., 22-6): active when hour >= start OR hour < end
       if [ "$HOUR" -lt "$AH_START" ] && [ "$HOUR" -ge "$AH_END" ]; then
         echo "OUTSIDE_ACTIVE_HOURS"
-        exit 1
+        exit 0
       fi
     fi
   fi
@@ -76,4 +81,4 @@ if [ "$COUNT" -gt 0 ]; then
 fi
 
 echo "NO_WORK"
-exit 1
+exit 0

--- a/tests/gh-issue-autopilot/test-active-hours.sh
+++ b/tests/gh-issue-autopilot/test-active-hours.sh
@@ -159,8 +159,8 @@ if gh auth status >/dev/null 2>&1; then
 
   test_start "no activeHours does not block"
   output="$(cd "$REPO_ROOT" && CURRENT_HOUR=3 bash "$PRECHECK" 2>&1)" && exit_code=0 || exit_code=$?
-  # Should exit non-zero because no matching issues, but NOT because of hours
-  assert_equals "exits non-zero (no work)" "1" "$exit_code"
+  # Should exit zero with NO_WORK output (no matching issues, but NOT because of hours)
+  assert_equals "exits zero (no work)" "0" "$exit_code"
   assert_contains "output is NO_WORK (not hours)" "$output" "NO_WORK"
 
   # ── Normal range: inside active hours ─────────────────────────
@@ -172,7 +172,7 @@ if gh auth status >/dev/null 2>&1; then
 
   test_start "hour 12 inside 9-17"
   output="$(cd "$REPO_ROOT" && CURRENT_HOUR=12 bash "$PRECHECK" 2>&1)" && exit_code=0 || exit_code=$?
-  assert_equals "exits non-zero (no work, but not hours)" "1" "$exit_code"
+  assert_equals "exits zero (no work, but not hours)" "0" "$exit_code"
   assert_contains "output is NO_WORK" "$output" "NO_WORK"
 
   test_start "hour 9 inside 9-17 (boundary)"
@@ -186,7 +186,7 @@ if gh auth status >/dev/null 2>&1; then
 
   test_start "hour 5 outside 9-17"
   output="$(cd "$REPO_ROOT" && CURRENT_HOUR=5 bash "$PRECHECK" 2>&1)" && exit_code=0 || exit_code=$?
-  assert_equals "exits non-zero" "1" "$exit_code"
+  assert_equals "exits zero" "0" "$exit_code"
   assert_contains "output is OUTSIDE_ACTIVE_HOURS" "$output" "OUTSIDE_ACTIVE_HOURS"
 
   test_start "hour 17 outside 9-17 (boundary, end is exclusive)"

--- a/tests/gh-issue-autopilot/test-precheck.sh
+++ b/tests/gh-issue-autopilot/test-precheck.sh
@@ -53,7 +53,7 @@ if gh auth status >/dev/null 2>&1; then
   done
 
   # Run precheck from the repo root (no active issue, no matching issues)
-  test_start "exits non-zero when no work"
+  test_start "exits zero with NO_WORK when no work"
   output="$(cd "$REPO_ROOT" && bash "$PRECHECK" 2>&1)" && exit_code=0 || exit_code=$?
 
   # Restore active issue files
@@ -68,7 +68,7 @@ if gh auth status >/dev/null 2>&1; then
     rm -f "$CONFIG_FILE"
   fi
 
-  assert "exits non-zero" test "$exit_code" -ne 0
+  assert_equals "exits zero" "0" "$exit_code"
   assert_contains "outputs NO_WORK" "$output" "NO_WORK"
 
   # ── Active issue scenario ─────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Changed `precheck.sh` to always exit 0 on success, using output strings (`NO_WORK`, `OUTSIDE_ACTIVE_HOURS`, `ACTIVE_ISSUE:*`, `ISSUES_FOUND:*`) to communicate the result
- Non-zero exit codes now indicate actual errors (e.g., `gh` CLI failure), not valid skip conditions
- Updated SKILL.md scan documentation to check output strings instead of exit codes
- Updated tests to expect exit 0 for no-work and outside-hours cases

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)