### PR TITLE
Add get_history tool to homeassistant-mcp

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
     {
       "name": "homeassistant-mcp",
       "description": "MCP server for Home Assistant: entity state, service calls, and CRUD for automations, scripts, scenes, and helpers.",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "source": "./plugins/homeassistant-mcp"
     }
   ]

--- a/plugins/homeassistant-mcp/.claude-plugin/plugin.json
+++ b/plugins/homeassistant-mcp/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "homeassistant-mcp",
   "description": "MCP server for Home Assistant: entity state, service calls, and CRUD for automations, scripts, scenes, and helpers.",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "author": {
     "name": "mover5"
   }

--- a/plugins/homeassistant-mcp/README.md
+++ b/plugins/homeassistant-mcp/README.md
@@ -11,6 +11,7 @@ Minimal MCP server for Home Assistant. Exposes entity state, service calls, and 
 | `list_entities` | List entities (optional `domain` filter) |
 | `get_state` | Full state + attributes for one `entity_id` |
 | `get_logbook` | Recent logbook events (default last 7 days, noise-filtered); `include_noisy: true` for raw |
+| `get_history` | Numerical state-change history for any entity (default last 24h). Wraps HA's `/api/history/period` — works for noisy sensors (`_signal`, `_battery`, `_energy`, etc.) that `get_logbook` filters out by design. `summarize: true` returns per-entity min/max/mean/count; raw mode is downsampled to `max_points` (default 500). |
 | `call_service` | Call any HA service — **subject to deny-list** |
 
 **Automations / scripts / scenes** — same six tools per domain:

--- a/plugins/homeassistant-mcp/package.json
+++ b/plugins/homeassistant-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ha-mcp",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "MCP server for Home Assistant: entity state, service calls, and automation CRUD",
   "type": "module",
   "scripts": {

--- a/plugins/homeassistant-mcp/src/index.ts
+++ b/plugins/homeassistant-mcp/src/index.ts
@@ -303,10 +303,10 @@ function missingReferencesError(missing: string[], op: string, label: string) {
 }
 
 const server = new McpServer(
-  { name: 'home-assistant', version: '0.2.0' },
+  { name: 'home-assistant', version: '0.4.0' },
   {
     instructions:
-      'Home Assistant MCP server. Discover with list_entities / get_state / get_logbook (recent events, noise-filtered by default). Act with call_service (subject to deny-list). Manage config-backed entities with the automation / script / scene tools — call the matching reload_* after create/update/delete. Helpers (input_*, timer, counter) use the WebSocket API and apply immediately, so no reload step is needed.',
+      'Home Assistant MCP server. Discover with list_entities / get_state. For history: get_logbook = human-readable events (filtered, no numerical sensors); get_history = raw time-series for any entity (works on noisy numerical sensors like signal/battery/energy/temperature that the logbook hides). Act with call_service (subject to deny-list). Manage config-backed entities with the automation / script / scene tools — call the matching reload_* after create/update/delete. Helpers (input_*, timer, counter) use the WebSocket API and apply immediately, so no reload step is needed.',
   },
 );
 
@@ -456,6 +456,180 @@ server.registerTool(
       filtered: !include_noisy,
       count: events.length,
       events,
+    });
+  },
+);
+
+// ---- History ----
+//
+// HA's logbook API filters out many noisy domains (sensor, weather, ...) and
+// substring patterns (_signal, _battery, ...) by design — even include_noisy on
+// get_logbook can't get them, because HA's own /api/logbook never returned them.
+// The History panel in HA uses /api/history/period instead, which returns raw
+// state-change records for any entity. This tool wraps that endpoint.
+
+interface HistoryPoint {
+  entity_id?: string;
+  state?: string;
+  last_changed?: string;
+  last_updated?: string;
+  attributes?: Record<string, unknown>;
+}
+
+function tryParseFloat(s: string | undefined | null): number | null {
+  if (s === undefined || s === null || s === '') return null;
+  const n = Number(s);
+  return Number.isFinite(n) ? n : null;
+}
+
+function downsampleUniform<T>(items: T[], max: number): T[] {
+  if (items.length <= max) return items;
+  const out: T[] = [];
+  const step = (items.length - 1) / (max - 1);
+  for (let i = 0; i < max; i++) out.push(items[Math.round(i * step)]);
+  return out;
+}
+
+server.registerTool(
+  'get_history',
+  {
+    description:
+      "Fetch numerical state-change history for one or more entities. Wraps HA's /api/history/period (what the History panel uses) — works for noisy numerical sensors that get_logbook filters out (signal strength, battery, energy, temperature, etc.). Default window is the last 24h. Use summarize=true for per-entity {first, last, min, max, mean, count} instead of raw points. Raw points are uniformly downsampled to max_points (default 500) to keep responses manageable for high-frequency sensors. For multiple entities pass a comma-separated entity_id (e.g. \"sensor.a,sensor.b\").",
+    inputSchema: {
+      entity_id: z
+        .string()
+        .describe(
+          'Entity to fetch. For multiple entities, pass a comma-separated list (e.g. "sensor.a,sensor.b").',
+        ),
+      hours_back: z
+        .number()
+        .min(0.1)
+        .max(720)
+        .optional()
+        .describe(
+          'Window size in hours, ending now. Default 24 (last 24h). Ignored if start is provided.',
+        ),
+      start: z
+        .string()
+        .optional()
+        .describe('ISO 8601 start time (e.g. "2026-06-29T00:00:00Z"). Overrides hours_back.'),
+      end: z.string().optional().describe('ISO 8601 end time. Defaults to now.'),
+      summarize: z
+        .boolean()
+        .optional()
+        .describe(
+          'If true, return per-entity {count, first/last state+time, numeric {min, max, mean}} instead of raw points. Default false.',
+        ),
+      significant_only: z
+        .boolean()
+        .optional()
+        .describe(
+          "Apply HA's significant-changes filter (skips micro-fluctuations). Default true.",
+        ),
+      include_attributes: z
+        .boolean()
+        .optional()
+        .describe(
+          'If true, include attributes on each raw point. Default false (much smaller responses). Ignored in summarize mode.',
+        ),
+      max_points: z
+        .number()
+        .int()
+        .min(1)
+        .max(5000)
+        .optional()
+        .describe(
+          'Cap on raw points returned per entity. Series longer than this are uniformly downsampled. Default 500. Ignored in summarize mode.',
+        ),
+    },
+  },
+  async ({
+    entity_id,
+    hours_back,
+    start,
+    end,
+    summarize,
+    significant_only,
+    include_attributes,
+    max_points,
+  }) => {
+    const sigOnly = significant_only ?? true;
+    const includeAttrs = include_attributes ?? false;
+    const cap = max_points ?? 500;
+    const doSummary = summarize ?? false;
+
+    const now = new Date();
+    const endIso = end ?? now.toISOString();
+    const startIso = start ?? new Date(now.getTime() - (hours_back ?? 24) * 3_600_000).toISOString();
+
+    const params = new URLSearchParams({
+      filter_entity_id: entity_id,
+      end_time: endIso,
+      minimal_response: 'true',
+    });
+    if (sigOnly) params.set('significant_changes_only', 'true');
+    if (!includeAttrs) params.set('no_attributes', 'true');
+
+    const raw = (await ha(
+      `/api/history/period/${startIso}?${params.toString()}`,
+    )) as HistoryPoint[][];
+
+    const series = (raw ?? []).map((points) => {
+      const eid = points[0]?.entity_id ?? '';
+      if (doSummary) {
+        let min = Infinity;
+        let max = -Infinity;
+        let sum = 0;
+        let n = 0;
+        for (const p of points) {
+          const v = tryParseFloat(p.state);
+          if (v === null) continue;
+          if (v < min) min = v;
+          if (v > max) max = v;
+          sum += v;
+          n++;
+        }
+        const first = points[0];
+        const last = points[points.length - 1];
+        const summary: Record<string, unknown> = {
+          entity_id: eid,
+          count: points.length,
+          first_at: first?.last_changed ?? first?.last_updated ?? null,
+          last_at: last?.last_changed ?? last?.last_updated ?? null,
+          first_state: first?.state ?? null,
+          last_state: last?.state ?? null,
+        };
+        if (n > 0) {
+          summary.numeric = {
+            numeric_count: n,
+            min,
+            max,
+            mean: Number((sum / n).toFixed(4)),
+          };
+        }
+        return summary;
+      } else {
+        const sampled = downsampleUniform(points, cap);
+        return {
+          entity_id: eid,
+          count: points.length,
+          returned: sampled.length,
+          downsampled: sampled.length < points.length,
+          points: sampled.map((p) => ({
+            t: p.last_changed ?? p.last_updated ?? '',
+            state: p.state ?? '',
+            ...(includeAttrs && p.attributes ? { attributes: p.attributes } : {}),
+          })),
+        };
+      }
+    });
+
+    return textResult({
+      period: { start: startIso, end: endIso },
+      mode: doSummary ? 'summary' : 'points',
+      significant_only: sigOnly,
+      series_count: series.length,
+      series,
     });
   },
 );


### PR DESCRIPTION
## Summary

- Adds a new `get_history` MCP tool that wraps HA's `/api/history/period` endpoint, exposing time-series state-change data for any entity.
- Fills the gap where the existing `get_logbook` tool (`/api/logbook`) hides noisy numerical sensors (`signal_strength`, `battery`, `energy`, temperature, etc.) by HA's own server-side design — even `include_noisy=true` can't retrieve them, because HA never returns them on that endpoint.
- Defaults sized for token-sane responses: 24h window, significant-changes-only, no attributes, uniform downsample to 500 points. A `summarize=true` mode returns per-entity `{count, first/last state+time, numeric: {min, max, mean}}` instead of raw points for cheap trend queries.

Motivated by trying to verify the WiFi signal trend on a CircuitSetup energy meter after swapping in a WROOM-32U board — `get_logbook` returned 0 events for `sensor.*_wifi_signal` even though HA's History panel showed full data.

## Test plan

- [x] `npm run typecheck` clean
- [ ] Install via marketplace bump (0.6.0 → 0.7.0), restart Claude Code, call `get_history` with `entity_id=sensor.whole_house_energy_meter_wifi_signal, hours_back=24, summarize=true` — confirm non-zero `count` and sensible `numeric.{min,max,mean}` around current ~-35 dBm
- [ ] Call with `summarize=false` — confirm `points[]` is returned and `downsampled=true` when `count > 500`
- [ ] Call with comma-separated `entity_id` — confirm `series` has 2 entries
- [ ] Call with no `hours_back` — confirm default 24h window

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FfaKGLPPkKRQQ67x5Nnth1